### PR TITLE
Polish - revision 15 for android

### DIFF
--- a/src/languages/pl/impl.json
+++ b/src/languages/pl/impl.json
@@ -3,8 +3,8 @@
   "pseudoEnglish": false,
 "version": {
 "major": 1,
-"minor": 14
+"minor": 15
 },
-"dataUrl": "https://github.com/RHVoice/Polish/releases/download/14/RHVoice-language-Polish-v1.14.zip",
-"dataMd5": "f5ahBhrxaK735jAh+cuUgA=="
+"dataUrl": "https://github.com/RHVoice/Polish/releases/download/15/RHVoice-language-Polish-v1.15.zip",
+"dataMd5": "BJ6EZDW1ypaLhcDT7FFLYQ=="
 }


### PR DESCRIPTION
note: targets alpha and stable: it is a quick fix, which corrects the pronounciation of w and z as individual letters, and w and z in words, and when these are surrounded by other symbols.