### PR TITLE
Added Python script for calculating MD5 hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ Some notes on the expected formats of values:
   ```
   openssl md5 -binary <YourPackageFile> | base64
   ```
+  Also, you can use the md5_hash Python script from the packages directory.
+  To use the md5_hash Python script, you need to specify a directory containing language and voice packages, and to specify a file name where MD5 hashes will be stored, (EG)
+  ```
+  md5_hash </home/packages> </home/md5_hashes.txt>
+  ``````
+  From Windows:
+  ```
+  python md5_hash <D:\packages> <D:\md5_hashes.txt>
+  ``````
 
 ### Check your changes
 

--- a/md5_hash
+++ b/md5_hash
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+import sys
+import os
+import hashlib
+import base64
+import zipfile
+
+def calculate_md5(input_file):
+    with open(input_file, 'rb') as f:
+        data = f.read()
+        md5hash = hashlib.md5(data).hexdigest()
+    return md5hash
+
+def calculate_base64(md5_hex):
+    base64_hash = base64.b64encode(bytes.fromhex(md5_hex)).decode()
+    return base64_hash
+
+if len(sys.argv)!=3:
+    print(sys.argv[0]+' directory_name file_name')
+    sys.exit(0)
+hashes = ""
+file_counter = 1
+files = os.listdir(sys.argv[1])
+for file in files:
+    if os.path.isfile(os.path.join(sys.argv[1], file)):
+        if zipfile.is_zipfile(os.path.join(sys.argv[1], file)):
+            hashes = hashes+file+"\nHASH:\n"+calculate_base64(calculate_md5(os.path.join(sys.argv[1], file)))+"\n"
+            file_counter = file_counter+1
+with open(sys.argv[2], "w") as f:
+    f.write(hashes)
+print('MD5 hash for '+str(file_counter)+' files has been calculated.')


### PR DESCRIPTION
Python script for calculating MD5 has been added to the packages directory.
It looks all archive files and calculates the MD5 using base64.
Also, readme.md file with instructions how to use the md5_hash Python script has been updated.